### PR TITLE
Messages override

### DIFF
--- a/src/templates/joomlade/html/layouts/joomla/system/messages.php
+++ b/src/templates/joomlade/html/layouts/joomla/system/messages.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+$msgList = $displayData['msgList'];
+
+$map = array(
+	'message' => 'success',
+	'error' => 'danger',
+);
+
+?>
+<div id="system-message-container">
+	<?php if (is_array($msgList) && !empty($msgList)) : ?>
+		<div id="system-message">
+			<?php foreach ($msgList as $type => $msgs) : ?>
+				<div class="alert alert-<?php echo $map[$type]; ?>">
+					<?php // This requires JS so we should add it through JS. Progressive enhancement and stuff. ?>
+					<a class="close" data-dismiss="alert">×</a>
+
+					<?php if (!empty($msgs)) : ?>
+						<h4 class="alert-heading"><?php echo JText::_($type); ?></h4>
+						<div>
+							<?php foreach ($msgs as $msg) : ?>
+								<div class="alert-message"><?php echo $msg; ?></div>
+							<?php endforeach; ?>
+						</div>
+					<?php endif; ?>
+				</div>
+			<?php endforeach; ?>
+		</div>
+	<?php endif; ?>
+</div>

--- a/src/templates/joomlade/html/layouts/joomla/system/messages.php
+++ b/src/templates/joomlade/html/layouts/joomla/system/messages.php
@@ -13,7 +13,7 @@ $msgList = $displayData['msgList'];
 
 $map = array(
 	'message' => 'success',
-	'error' => 'danger',
+	'error'   => 'danger',
 );
 
 ?>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2596554/26503381/c44b2820-4240-11e7-9a65-6f6bae021887.png)


ggf. noch ein override für die `close` klasse ohne text decoration. ?